### PR TITLE
fix STM32CubeMX code generation

### DIFF
--- a/CM7/Core/Inc/main.h
+++ b/CM7/Core/Inc/main.h
@@ -1,21 +1,21 @@
 /* USER CODE BEGIN Header */
 /**
-  ******************************************************************************
-  * @file           : main.h
-  * @brief          : Header for main.c file.
-  *                   This file contains the common defines of the application.
-  ******************************************************************************
-  * @attention
-  *
-  * Copyright (c) 2023 STMicroelectronics.
-  * All rights reserved.
-  *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file           : main.h
+ * @brief          : Header for main.c file.
+ *                   This file contains the common defines of the application.
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2023 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
 /* USER CODE END Header */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -130,13 +130,12 @@ extern volatile atomic_uint main_tasks;
 #define OLD_MOTOR2_ENCODER_GPIO_Port GPIOE
 #define LED_YELLOW_Pin GPIO_PIN_1
 #define LED_YELLOW_GPIO_Port GPIOE
+
+/* USER CODE BEGIN Private defines */
 #define IMU_SCL_Pin GPIO_PIN_14
 #define IMU_SCL_GPIO_Port GPIOF
 #define IMU_SDA_Pin GPIO_PIN_15
 #define IMU_SDA_GPIO_Port GPIOF
-
-
-/* USER CODE BEGIN Private defines */
 #define MOTOR1_TIM_CHANNEL TIM_CHANNEL_1
 #define MOTOR2_TIM_CHANNEL TIM_CHANNEL_1
 #define MOTOR3_TIM_CHANNEL TIM_CHANNEL_3

--- a/CM7/Core/Src/main.c
+++ b/CM7/Core/Src/main.c
@@ -303,6 +303,7 @@ void SystemClock_Config(void) {
   }
 }
 
+/* USER CODE BEGIN I2C4_Init 0 */
 /* Initialize I2C for IMU */
 static void I2C4_Init(void) {
   __HAL_RCC_I2C4_CLK_ENABLE();
@@ -327,6 +328,7 @@ static void I2C4_Init(void) {
     Error_Handler();
   }
 }
+/* USER CODE END I2C4_Init 0 */
 
 /**
  * @brief SPI1 Initialization Function
@@ -913,6 +915,12 @@ static void MX_GPIO_Init(void) {
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(NRF_CE_GPIO_Port, &GPIO_InitStruct);
 
+  /* EXTI interrupt init*/
+  HAL_NVIC_SetPriority(EXTI15_10_IRQn, 7, 0);
+  HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
+
+  /* USER CODE BEGIN MX_GPIO_Init_2 */
+
   /* Configure IMU_SCL_Pin */
   GPIO_InitStruct.Pin = IMU_SCL_Pin;
   GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
@@ -928,12 +936,6 @@ static void MX_GPIO_Init(void) {
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
   GPIO_InitStruct.Alternate = GPIO_AF4_I2C4;
   HAL_GPIO_Init(IMU_SDA_GPIO_Port, &GPIO_InitStruct);
-
-  /* EXTI interrupt init*/
-  HAL_NVIC_SetPriority(EXTI15_10_IRQn, 7, 0);
-  HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
-
-  /* USER CODE BEGIN MX_GPIO_Init_2 */
 
   /* USER CODE END MX_GPIO_Init_2 */
 }


### PR DESCRIPTION
- [x] My code follows the [style guidelines](https://github.com/LiU-SeeGoals/wiki/wiki/1.1.-Processes-&-Standards#seegoal---firmware-standard) of this project
- [x] I've compared the local **basestation.ioc** with main branches .ioc and made sure no pin's has been relocated.
- [x] I've set an responsible reviewer and pinged this person on Discord.
